### PR TITLE
Remove annotation popover label from Red Pen UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -380,16 +380,6 @@
   }
   #popover.visible { display: block; }
 
-  .popover-label {
-    font-size: 11px;
-    font-weight: 600;
-    color: var(--text-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.07em;
-    margin-bottom: 12px;
-    font-family: var(--sans);
-  }
-
   .popover-excerpt {
     font-size: 13px;
     font-family: var(--display);
@@ -753,7 +743,6 @@
 </div>
 
 <div id="popover">
-  <div class="popover-label">Add note</div>
   <div class="popover-excerpt" id="popover-excerpt"></div>
   <textarea id="comment-input" placeholder="What should change? (optional)"></textarea>
   <div class="popover-footer">


### PR DESCRIPTION
### Motivation
- Simplify the annotation popover UI by removing the redundant heading text so the dialog presents the excerpt and input controls directly.

### Description
- Remove the `<div class="popover-label">Add note</div>` element from the popover markup in `index.html` and delete the now-unused `.popover-label` CSS rule.

### Testing
- Ran a project search for `popover-label` and `Add note` and confirmed no remaining references; reviewed the file changes to ensure only the popover label markup and its CSS rule were removed and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3f05240888330a03ce47d512e6459)